### PR TITLE
Install `ebtel++` on CI

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -14,12 +14,36 @@ jobs:
         with:
           fetch-depth: 0
 
+      - name: Clone ebtel++
+        uses: actions/checkout@v4
+        with:
+          repository: jwreep/ebtelPlusPlus
+          ref: main
+
+      - name: Install Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: "3.10"
+
+      - name: Install dependencies
+        run: |
+          pip install scons
+          sudo apt-get update
+          sudo apt-get install libboost-all-dev
+
+      - name: Install ebtel++
+        run: |
+          cd ebtelPlusPlus
+          scons
+          cd ..
+        
       - name: Build the article PDF
         id: build
         with:
           showyourwork-spec: git+https://github.com/showyourwork/showyourwork
         uses: showyourwork/showyourwork-action@v1
         env:
+          EBTELPLUSPLUS_DIR: ${{ github.workspace }}/ebtelPlusPlus
           SANDBOX_TOKEN: ${{ secrets.SANDBOX_TOKEN }}
           OVERLEAF_EMAIL: ${{ secrets.OVERLEAF_EMAIL }}
           OVERLEAF_PASSWORD: ${{ secrets.OVERLEAF_PASSWORD }}

--- a/src/scripts/paths.py
+++ b/src/scripts/paths.py
@@ -2,6 +2,7 @@
 Exposes common paths useful for manipulating datasets and generating figures.
 
 """
+import os
 from pathlib import Path
 
 # Absolute path to the top level of the repository
@@ -29,5 +30,4 @@ figures = tex / "figures"
 output = tex / "output"
 
 # Absolute path to the ebtel++ code
-# Replace this with the correct "path/to/ebtel"
-ebtel_root = Path("/path/to/ebtelPlusPlus")
+ebtel_root = Path(os.environ['EBTELPLUSPLUS_DIR'])


### PR DESCRIPTION
This PR does two things:

1. Pulls the path to `ebtel++` from an environment variable `EBTELPLUSPLUS_DIR`
2. Adds a few steps in the GH Actions script to install `ebtel++` on the CI

This may require a bit of debugging.